### PR TITLE
Clean Retained using the same connection

### DIFF
--- a/src/clean_retained.rs
+++ b/src/clean_retained.rs
@@ -12,7 +12,7 @@ pub fn gather_topics_and_clean(
     base_topic: &str,
     mode: Mode,
 ) {
-    let mut known_topics: Vec<(String, bool)> = Vec::new();
+    let mut known_topics: Vec<String> = Vec::new();
     loop {
         match connection.iter().next() {
             Some(Ok(Event::Incoming(Packet::Publish(publish)))) => {
@@ -20,9 +20,7 @@ pub fn gather_topics_and_clean(
                     // First non retained means we exit
                     break;
                 } else {
-                    let topic = publish.topic;
-                    let known = (topic.to_string(), true);
-                    known_topics.push(known);
+                    known_topics.push(publish.topic.to_string());
                 }
             }
             Some(Ok(Event::Incoming(Packet::Disconnect))) => {
@@ -46,13 +44,13 @@ pub fn gather_topics_and_clean(
 pub fn clean_retained(
     client: &mut Client,
     base_topic: &str,
-    known_topics: Vec<&(String, bool)>,
+    known_topics: Vec<&String>,
     mode: Mode,
 ) {
     let filtered_topics = known_topics
         .iter()
-        .filter_map(|(t, retained)| {
-            if t.starts_with(base_topic) && *retained {
+        .filter_map(|t| {
+            if t.starts_with(base_topic) {
                 Some(t)
             } else {
                 None

--- a/src/interactive/clear_retained.rs
+++ b/src/interactive/clear_retained.rs
@@ -1,4 +1,3 @@
-use rumqttc::MqttOptions;
 use tui::backend::Backend;
 use tui::layout::{Alignment, Rect};
 use tui::style::{Color, Modifier, Style};

--- a/src/interactive/clear_retained.rs
+++ b/src/interactive/clear_retained.rs
@@ -6,6 +6,8 @@ use tui::text::{Span, Spans};
 use tui::widgets::{Block, Borders, Clear, Paragraph};
 use tui::Frame;
 
+use super::mqtt_thread::MqttThread;
+
 pub fn draw_popup<B: Backend>(f: &mut Frame<B>, topic: &str) {
     let block = Block::default()
         .border_style(Style::default().fg(Color::Red))
@@ -41,28 +43,17 @@ fn popup_area(r: Rect) -> Rect {
 
 // TODO: use mqtt_thread instead of new mqtt connection
 // some people have strict requirements on their connection so a new connection wont help them here
-pub fn do_clear(base: &MqttOptions, topic: &str) -> anyhow::Result<()> {
-    let client_id = format!("mqttui-clean-{:x}", rand::random::<u32>());
+pub fn do_clear(mqtt_thread: &MqttThread, topic: &str) -> anyhow::Result<()> {
+    let known_topics = mqtt_thread.get_topics().unwrap();
+    let known_topics = known_topics.iter().collect::<Vec<_>>();
+    let mut client = mqtt_thread.get_mqtt_client().clone();
 
-    let (host, port) = base.broker_address();
-    let mut options = rumqttc::MqttOptions::new(client_id, host, port);
-    if let Some((username, password)) = base.credentials() {
-        options.set_credentials(username, password);
-    }
-
-    let (mut client, connection) = rumqttc::Client::new(options, 100);
-    client.subscribe(topic, rumqttc::QoS::AtLeastOnce)?;
-    client.subscribe(format!("{}/#", topic), rumqttc::QoS::AtLeastOnce)?;
-
-    std::thread::Builder::new()
-        .name(format!("clean retained {}", topic))
-        .spawn(move || {
-            crate::clean_retained::clean_retained(
-                client,
-                connection,
-                crate::clean_retained::Mode::Silent,
-            );
-        })?;
+    crate::clean_retained::clean_retained(
+        &mut client,
+        topic,
+        known_topics,
+        crate::clean_retained::Mode::Silent,
+    );
 
     Ok(())
 }

--- a/src/interactive/mod.rs
+++ b/src/interactive/mod.rs
@@ -319,8 +319,7 @@ impl App {
             },
             ElementInFocus::CleanRetainedPopup(topic) => {
                 if matches!(key.code, KeyCode::Enter | KeyCode::Char(' ')) {
-                    let base = self.mqtt_thread.get_mqtt_options();
-                    clear_retained::do_clear(base, topic)?;
+                    clear_retained::do_clear(&self.mqtt_thread, topic)?;
                 }
                 self.focus = ElementInFocus::TopicOverview;
                 Refresh::Update

--- a/src/interactive/mqtt_thread.rs
+++ b/src/interactive/mqtt_thread.rs
@@ -12,7 +12,7 @@ type ConnectionErrorArc = Arc<RwLock<Option<ConnectionError>>>;
 type HistoryArc = Arc<RwLock<MqttHistory>>;
 
 /// The known topics, and if they were retained(true) or not
-type KnownTopicsArc = Arc<RwLock<HashSet<(String, bool)>>>;
+type KnownTopicsArc = Arc<RwLock<HashSet<String>>>;
 
 pub struct MqttThread {
     connection_err: ConnectionErrorArc,
@@ -79,7 +79,7 @@ impl MqttThread {
             .read()
             .map_err(|err| anyhow::anyhow!("failed to aquire lock of mqtt history: {}", err))
     }
-    pub fn get_topics(&self) -> anyhow::Result<RwLockReadGuard<HashSet<(String, bool)>>> {
+    pub fn get_topics(&self) -> anyhow::Result<RwLockReadGuard<HashSet<String>>> {
         self.known_topics
             .read()
             .map_err(|err| anyhow::anyhow!("failed to aquire lock of known_topics: {}", err))
@@ -116,10 +116,7 @@ fn thread_logic(
                         }
                         let time = Local::now();
                         history.write().unwrap().add(&publish, time);
-                        known_topics
-                            .write()
-                            .unwrap()
-                            .insert((publish.topic, publish.retain));
+                        known_topics.write().unwrap().insert(publish.topic);
                     }
                     rumqttc::Event::Outgoing(rumqttc::Outgoing::Disconnect) => {
                         break;

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ fn main() -> anyhow::Result<()> {
                 clean_retained::Mode::Normal
             };
             client.subscribe(topic, QoS::AtLeastOnce)?;
-            clean_retained::clean_retained(client, connection, mode);
+            //clean_retained::clean_retained(client, connection, mode);
         }
         Some(SubCommands::Log { topic, verbose }) => {
             for topic in topic {

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,8 +65,8 @@ fn main() -> anyhow::Result<()> {
             } else {
                 clean_retained::Mode::Normal
             };
-            client.subscribe(topic, QoS::AtLeastOnce)?;
-            //clean_retained::clean_retained(client, connection, mode);
+            client.subscribe(topic.clone(), QoS::AtLeastOnce)?;
+            clean_retained::gather_topics_and_clean(&mut client, connection, &topic, mode);
         }
         Some(SubCommands::Log { topic, verbose }) => {
             for topic in topic {


### PR DESCRIPTION
Since clean retained would create a new connect, It did not work for our usecases, this changes that behaviour to use the same connection instead. 

It does this by keeping a list of all known topics, and if they are retained or not. And if they are considered retained, an empty payload is sent to that topic.  