### PR TITLE
feat: implement topic search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Interactive: Topic search
 - Interactive graph plots values with units will ignore everything after the whitespace (`20.0 °C` → `20.0`)
 
 ### Changed

--- a/src/interactive/footer.rs
+++ b/src/interactive/footer.rs
@@ -22,7 +22,7 @@ impl Footer {
         }
     }
 
-    pub fn draw(&self, f: &mut Frame, area: Rect, focus: &ElementInFocus) {
+    pub fn draw(&self, f: &mut Frame, area: Rect, focus: &ElementInFocus, topic_search: &str) {
         const STYLE: Style = Style::new()
             .fg(Color::Black)
             .bg(Color::White)
@@ -33,8 +33,18 @@ impl Footer {
                 Span::raw(" Quit  "),
                 Span::styled("Tab", STYLE),
                 Span::raw(" Switch to JSON Payload  "),
+                Span::styled("/", STYLE),
+                Span::raw(" Search  "),
                 Span::styled("Del", STYLE),
                 Span::raw(" Clean retained  "),
+            ],
+            ElementInFocus::TopicSearch => vec![
+                Span::styled("Enter", STYLE),
+                Span::raw(" Next  "),
+                Span::styled("Esc", STYLE),
+                Span::raw(" Clear  "),
+                Span::raw("Search: "),
+                Span::raw(topic_search),
             ],
             ElementInFocus::JsonPayload => vec![
                 Span::styled("q", STYLE),

--- a/src/interactive/footer.rs
+++ b/src/interactive/footer.rs
@@ -31,12 +31,12 @@ impl Footer {
             ElementInFocus::TopicOverview => vec![
                 Span::styled("q", STYLE),
                 Span::raw(" Quit  "),
-                Span::styled("Tab", STYLE),
-                Span::raw(" Switch to JSON Payload  "),
                 Span::styled("/", STYLE),
                 Span::raw(" Search  "),
                 Span::styled("Del", STYLE),
                 Span::raw(" Clean retained  "),
+                Span::styled("Tab", STYLE),
+                Span::raw(" Switch to JSON Payload  "),
             ],
             ElementInFocus::TopicSearch => vec![
                 Span::styled("Enter", STYLE),

--- a/src/interactive/footer.rs
+++ b/src/interactive/footer.rs
@@ -5,7 +5,7 @@ use ratatui::widgets::Paragraph;
 use ratatui::Frame;
 
 use crate::cli::Broker;
-use crate::interactive::ElementInFocus;
+use crate::interactive::{App, ElementInFocus};
 
 const VERSION_TEXT: &str = concat!("mqttui ", env!("CARGO_PKG_VERSION"));
 
@@ -22,12 +22,12 @@ impl Footer {
         }
     }
 
-    pub fn draw(&self, f: &mut Frame, area: Rect, focus: &ElementInFocus, topic_search: &str) {
+    pub fn draw(&self, f: &mut Frame, area: Rect, app: &App) {
         const STYLE: Style = Style::new()
             .fg(Color::Black)
             .bg(Color::White)
             .add_modifier(Modifier::BOLD);
-        let line = Line::from(match focus {
+        let line = Line::from(match app.focus {
             ElementInFocus::TopicOverview => vec![
                 Span::styled("q", STYLE),
                 Span::raw(" Quit  "),
@@ -44,7 +44,7 @@ impl Footer {
                 Span::styled("Esc", STYLE),
                 Span::raw(" Clear  "),
                 Span::raw("Search: "),
-                Span::raw(topic_search),
+                Span::raw(&app.topic_overview.search),
             ],
             ElementInFocus::JsonPayload => vec![
                 Span::styled("q", STYLE),

--- a/src/interactive/footer.rs
+++ b/src/interactive/footer.rs
@@ -39,8 +39,12 @@ impl Footer {
                 Span::raw(" Switch to JSON Payload  "),
             ],
             ElementInFocus::TopicSearch => vec![
-                Span::styled("Enter", STYLE),
+                Span::styled("↑", STYLE),
+                Span::raw(" Before  "),
+                Span::styled("↓", STYLE),
                 Span::raw(" Next  "),
+                Span::styled("Enter", STYLE),
+                Span::raw(" Open All  "),
                 Span::styled("Esc", STYLE),
                 Span::raw(" Clear  "),
                 Span::raw("Search: "),

--- a/src/interactive/mod.rs
+++ b/src/interactive/mod.rs
@@ -515,8 +515,7 @@ impl App {
             f.render_widget(paragraph.alignment(Alignment::Center), header_area);
         }
 
-        self.footer
-            .draw(f, footer_area, &self.focus, &self.topic_overview.search);
+        self.footer.draw(f, footer_area, self);
         if let Some(connection_error) = connection_error {
             mqtt_error_widget::draw(f, error_area, "MQTT Connection Error", &connection_error);
         }

--- a/src/interactive/mod.rs
+++ b/src/interactive/mod.rs
@@ -162,7 +162,7 @@ where
     Ok(())
 }
 
-struct App {
+pub struct App {
     details: details::Details,
     focus: ElementInFocus,
     footer: footer::Footer,

--- a/src/interactive/mqtt_history.rs
+++ b/src/interactive/mqtt_history.rs
@@ -93,6 +93,12 @@ impl MqttHistory {
             .and_then(|node| node.value().history.last())
     }
 
+    pub fn get_all_topics(&self) -> Vec<&String> {
+        let mut topics = self.ids.keys().collect::<Vec<_>>();
+        topics.sort();
+        topics
+    }
+
     pub fn get_topics_below(&self, topic: &str) -> Vec<String> {
         fn build_recursive(prefix: &[&str], node: NodeRef<Topic>) -> Vec<String> {
             let mut topic = prefix.to_vec();

--- a/src/interactive/topic_overview.rs
+++ b/src/interactive/topic_overview.rs
@@ -9,6 +9,7 @@ use crate::interactive::ui::{focus_color, get_row_inside};
 #[derive(Default)]
 pub struct TopicOverview {
     pub last_area: Rect,
+    pub search: String,
     pub state: TreeState<String>,
 }
 

--- a/src/interactive/ui.rs
+++ b/src/interactive/ui.rs
@@ -5,6 +5,7 @@ pub const STYLE_BOLD: Style = Style::new().add_modifier(Modifier::BOLD);
 
 pub enum ElementInFocus {
     TopicOverview,
+    TopicSearch,
     JsonPayload,
     CleanRetainedPopup(String),
 }


### PR DESCRIPTION
First attempt of a topic search.

Known caveat: Currently only topics which were pushed are considered. for example searching for `ello` on `hello/world` will only pick `hello/world` and not `hello` in the tree as it was never published on its own. Not sure if I like that or not.

As of the discussion in #144 this search will likely supersede the filter as the latter is more complex with more UX consequences while a simple search is likely enough.

closes #48