### PR TITLE
feat(tui): for graph, ignore trailing whitespace and other data

### DIFF
--- a/src/interactive/details/history/graph_data.rs
+++ b/src/interactive/details/history/graph_data.rs
@@ -18,7 +18,7 @@ impl Point {
         let time = entry.time.as_optional()?;
         let y = match &entry.payload {
             Payload::NotUtf8(_) => None,
-            Payload::String(str) => str.parse::<f64>().ok(),
+            Payload::String(str) => str.splitn(2, char::is_whitespace).next().unwrap().parse::<f64>().ok(),
             Payload::Json(json) => {
                 let json = JsonSelector::get_selection(json, json_selector).unwrap_or(json);
                 match json {


### PR DESCRIPTION
This adds support for a typical message format where a number is followed by whitespace and a unit, e.g. "550 PPM" or "20.0 °C" or "9000 W", by ignoring the whitespace and everything after it.