### PR TITLE
docs(readme): update Arch Linux instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ mqttui "topic"
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/mqttui.svg)](https://repology.org/project/mqttui/versions)
 
-#### Arch Linux (AUR)
+#### Arch Linux
 
-`paru -S mqttui-bin` or `yay -S mqttui-bin`
+`pacman -S mqttui`
 
 #### Homebrew (Mac or Linux)
 


### PR DESCRIPTION
Hey!

I just moved the AUR package to the official repositories: <https://archlinux.org/packages/extra/x86_64/mqttui>

Thanks for the awesome tool! :bear:
