### PR TITLE
doc: fix typos

### DIFF
--- a/src/clean_retained.rs
+++ b/src/clean_retained.rs
@@ -16,7 +16,7 @@ pub fn clean_retained(client: &Client, mut connection: Connection, dry_run: bool
             }
             Ok(rumqttc::Event::Incoming(rumqttc::Packet::Publish(publish))) => {
                 if publish.payload.is_empty() {
-                    // Thats probably myself cleaning up
+                    // That's probably myself cleaning up
                     continue;
                 }
                 if !publish.retain {

--- a/src/interactive/mqtt_thread.rs
+++ b/src/interactive/mqtt_thread.rs
@@ -60,13 +60,13 @@ impl MqttThread {
     pub fn has_connection_err(&self) -> Option<String> {
         self.connection_err
             .read()
-            .expect("mqtt history thread paniced")
+            .expect("mqtt history thread panicked")
             .as_ref()
             .map(ToString::to_string)
     }
 
     pub fn get_history(&self) -> RwLockReadGuard<MqttHistory> {
-        self.history.read().expect("mqtt history thread paniced")
+        self.history.read().expect("mqtt history thread panicked")
     }
 
     pub fn clean_below(&self, topic: &str) -> anyhow::Result<()> {

--- a/src/mqtt/connect.rs
+++ b/src/mqtt/connect.rs
@@ -68,6 +68,6 @@ pub fn connect(
         }
     }
     Err(anyhow::anyhow!(
-        "The MQTT connection to {broker} ended unexpectedly before it was acknowleged."
+        "The MQTT connection to {broker} ended unexpectedly before it was acknowledged."
     ))
 }


### PR DESCRIPTION
Found via `codespell -L crate,ratatui,splitted`