### PR TITLE
build(deb): add "section" to deb package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ url = "2"
 # https://crates.io/crates/cargo-deb
 [package.metadata.deb]
 depends = ""
+section = "utility"
 assets = [
 	["target/release/mqttui", "/usr/bin/", "755"],
 	["CHANGELOG.md", "/usr/share/doc/mqttui/", "644"],

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ url = "2"
 # https://crates.io/crates/cargo-deb
 [package.metadata.deb]
 depends = ""
-section = "utility"
+section = "net"
 assets = [
 	["target/release/mqttui", "/usr/bin/", "755"],
 	["CHANGELOG.md", "/usr/share/doc/mqttui/", "644"],


### PR DESCRIPTION
TL;DR: This PR adds a [section](https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections) field to the deb metadata.  

Why I am proposing this:  
I'm building a custom Ubuntu distribution using [mkosi](https://github.com/systemd/mkosi/). I plan on including `mqttui` as a debugging tool. Because mqttui isn't available on `packages.ubuntu.com`, I resorted to downloading the .deb package straight from Github during an additional build step, which gets provided during the mkosi build. It uses reprepro under the hood, which seems to be skipping this specific package because of the lack of "section" field:
<details>
  <summary>mkosi build log</summary>

```

> .mkosi/bin/mkosi -C core/mkosi/os -f --initrd ../initrd/mkosi.output/initrd --package-directory=./mkosi.packages --package-directory=../../dist/deb --workspace-directory=../../tmp/mkosi

‣ Removing cache entries of default image…
‣ Validating certificates and keys
‣ Syncing package manager metadata
‣  Copying in sandbox trees…
Hit:1 https://repos.influxdata.com/debian stable InRelease
Hit:2 http://security.ubuntu.com/ubuntu oracular-security InRelease              
Hit:3 https://[REDACTED] stable InRelease                 
Hit:4 https://[REDACTED] nodistro InRelease                    
Hit:5 http://archive.ubuntu.com/ubuntu oracular InRelease                        
Hit:6 http://archive.ubuntu.com/ubuntu oracular-updates InRelease                
Hit:7 https://[REDACTED] noble InRelease
Reading package lists... Done
‣ Copying repository metadata
‣ Building default image
‣  Copying in sandbox trees…
‣  Copying in extra packages…
‣  Rebuilding local package repository
No section given for 'mqttui', skipping.
Warning: database 'mkosi|main|amd64' was modified but no index file was exported.
Changes will only be visible after the next 'export'!
There have been errors!
‣ "reprepro --ignore=extension includedeb mkosi mqttui-v0.21.1-x86_64-unknown-linux-gnu.deb [REDACTED]" returned non-zero exit code 255.
```

</details>


In conclusion, this PR mainly solves my niche usage, but I believe fixing it upstream instead of hacking around it for my own usage might benefit future users of the software. 
Thank you for designing, implementing and open-sourcing this project. I could relate to the conclusion of your README, this is a solid alternative to the good ol' MQTT explorer.  
Cheers