### PR TITLE
feat(encryption): Enable SSLKeyLog when `SSLKEYLOGFILE` is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Honors environment variable SSLKEYLOGFILE to dump TLS encryption secrets.
+
 ## [0.22.0] - 2025-03-01
 
 ### Added

--- a/src/mqtt/encryption.rs
+++ b/src/mqtt/encryption.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use rumqttc::TlsConfiguration;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified};
-use rustls::{ClientConfig, DigitallySignedStruct, SignatureScheme};
+use rustls::{ClientConfig, DigitallySignedStruct, KeyLogFile, SignatureScheme};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
 
 #[derive(Debug)]
@@ -85,6 +85,7 @@ pub fn create_tls_configuration(
         (None, None) => conf.with_no_client_auth(),
         _ => unreachable!("requires both cert and key which should be ensured by clap"),
     };
+    conf.key_log = Arc::new(KeyLogFile::new());
 
     if insecure {
         let mut danger = conf.dangerous();


### PR DESCRIPTION
Hello!

This PR adds support to setting the environment variable `SSLKEYLOGFILE` and getting a dump of the secret TLS keys used for `mqtts:` brokers.

This is useful to decrypt and study the MQTT protocol using capture tools such as Wireshark.

This feature is already implemented in `rustls` but disabled by default, as a security measure. But many tools, such as Firefox or Curl or WGet enable it unconditionally.

Note that if the `SSLKEYLOGFILE` environment variable is not set this does nothing.