### PR TITLE
build: Add docker container option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM docker.io/library/rust:1.74.0-bookworm AS builder
+WORKDIR /usr/local/src
+COPY . .
+RUN cargo build --release
+
+FROM gcr.io/distroless/cc-debian12:nonroot
+COPY --from=builder /usr/local/src/target/release/mqttui /usr/local/bin/mqttui
+ENTRYPOINT ["/usr/local/bin/mqttui"]

--- a/README.md
+++ b/README.md
@@ -154,6 +154,13 @@ Check the [Releases](https://github.com/EdJoPaTo/mqttui/releases).
 - Clone this repository
 - `cargo install --path .`
 
+### With Container
+
+```bash
+docker build . -t localhost/mqttui
+docker run --rm -it localhost/mqttui
+```
+
 ## History and Alternatives
 
 Taking a look into existing "lets just view MQTT right now" or "quickly publish something" projects they are always quite bulky and not that fast.


### PR DESCRIPTION
Containerizing mqttui makes it easier to use without installing it.

The container can then be used like this:
```bash
docker run --rm --init --interactive --tty localhost/mqttui
```

The docker image could be hosted on ghcr.io and its build automated via github action:
https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
