### PR TITLE
feat(tls): add AWS IoT Core support via --ca, --alpn, and --qos options

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -246,6 +246,52 @@ pub struct MqttConnection {
     /// Allow insecure TLS connections
     #[arg(long, global = true)]
     pub insecure: bool,
+
+    /// Path to a TLS CA certificate file.
+    ///
+    /// Used to verify the broker's certificate instead of using the system's certificate store.
+    /// Useful for self-signed certificates or private CA (like AWS `IoT` Core).
+    /// The file should contain PEM-encoded CA certificates.
+    #[arg(
+        long,
+        env = "MQTTUI_CA",
+        value_hint = ValueHint::FilePath,
+        value_name = "FILEPATH",
+        global = true,
+    )]
+    pub ca: Option<std::path::PathBuf>,
+
+    /// TLS ALPN protocol to use.
+    ///
+    /// Required by some brokers like AWS `IoT` Core.
+    /// Common values: "mqtt" for standard MQTT, "x-amzn-mqtt-ca" for AWS `IoT` custom auth.
+    /// Can be specified multiple times for multiple protocols (first is preferred).
+    #[arg(
+        long,
+        env = "MQTTUI_ALPN",
+        value_hint = ValueHint::Other,
+        value_name = "PROTOCOL",
+        global = true,
+    )]
+    pub alpn: Vec<String>,
+
+    /// MQTT `QoS` level for subscriptions and publishing.
+    ///
+    /// 0 = At most once (fire and forget)
+    /// 1 = At least once (acknowledged delivery)
+    /// 2 = Exactly once (assured delivery)
+    ///
+    /// Note: AWS `IoT` Core does not support `QoS` 2. Use --qos 1 for AWS `IoT`.
+    #[arg(
+        long,
+        env = "MQTTUI_QOS",
+        value_hint = ValueHint::Other,
+        value_name = "LEVEL",
+        default_value_t = 2,
+        value_parser = clap::value_parser!(u8).range(0..=2),
+        global = true,
+    )]
+    pub qos: u8,
 }
 
 #[derive(Debug, Clone)]

--- a/src/interactive/mod.rs
+++ b/src/interactive/mod.rs
@@ -62,9 +62,10 @@ pub fn show(
     broker: &Broker,
     subscribe_topic: Vec<String>,
     payload_size_limit: usize,
+    qos: rumqttc::QoS,
 ) -> anyhow::Result<()> {
     let mqtt_thread =
-        mqtt_thread::MqttThread::new(client, connection, subscribe_topic, payload_size_limit)?;
+        mqtt_thread::MqttThread::new(client, connection, subscribe_topic, payload_size_limit, qos)?;
     let app = App::new(broker, mqtt_thread);
 
     let original_hook = std::panic::take_hook();

--- a/src/mqtt/connect.rs
+++ b/src/mqtt/connect.rs
@@ -14,6 +14,9 @@ pub fn connect(
         client_cert,
         client_private_key,
         insecure,
+        ca,
+        alpn,
+        qos: _, // QoS is extracted separately in main.rs before this call
     }: MqttConnection,
     keep_alive: Option<Duration>,
 ) -> anyhow::Result<(Broker, Client, Connection)> {
@@ -24,6 +27,8 @@ pub fn connect(
                 insecure,
                 client_cert.as_deref(),
                 client_private_key.as_deref(),
+                ca.as_deref(),
+                &alpn,
             )?),
             host.clone(),
             *port,
@@ -35,6 +40,8 @@ pub fn connect(
                 insecure,
                 client_cert.as_deref(),
                 client_private_key.as_deref(),
+                ca.as_deref(),
+                &alpn,
             )?),
             url.to_string(),
             666,


### PR DESCRIPTION
  First-time contributor here. Happy to adjust anything based on feedback.  Claude Code did the work here with my prompting as I don't know Rust.  

  ## Summary

  Adds support for connecting to AWS IoT Core and other brokers that require:
  - Custom CA certificates (instead of system cert store)
  - TLS ALPN protocol negotiation
  - QoS levels other than 2

  ## Changes

  - `--ca <FILEPATH>` - Specify CA certificate file for broker verification
  - `--alpn <PROTOCOL>` - Set TLS ALPN protocol (e.g., "mqtt" for AWS IoT)
  - `--qos <LEVEL>` - Configure QoS level (0, 1, or 2) for interactive mode

  ## Backward Compatibility

  - Default QoS remains 2 for interactive mode
  - Subcommands (`log`, `read-one`, `publish`, `clean-retained`) retain original behavior
  - No changes required for existing users

  ## AWS IoT Core Usage

  ```bash
  mqttui \
    --broker mqtts://your-endpoint.iot.region.amazonaws.com:8883 \
    --ca AmazonRootCA1.pem \
    --client-cert device-cert.pem \
    --client-private-key device-key.pem \
    --alpn mqtt \
    --qos 1 \
    'your/topic/#'

  Note: AWS IoT Core does not support QoS 2. The interactive mode now shows a helpful hint when
  connection is closed, suggesting --qos 1.

  Test plan

  - Builds without warnings (cargo build)
  - All tests pass (cargo test)
  - Clippy clean (cargo clippy)
  - Tested with AWS IoT Core endpoint
  - Verified backward compatibility (existing commands work unchanged)

