### PR TITLE
feat(interactive): add persistent topic filter (closes #103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Interactive: Press `f` to activate a persistent topic filter. Only topics whose name or latest payload contains the filter string (case-insensitive) are shown. Press `Esc` to clear, `Enter` or `Tab` to confirm and keep the filter while returning to overview navigation. The active filter is shown in the topic pane title.
+
 ## [0.24.0] - 2026-08-09
 
 ### Added

--- a/src/interactive/footer.rs
+++ b/src/interactive/footer.rs
@@ -26,6 +26,28 @@ impl Footer {
         }
     }
 
+    fn render_version_info(&self, frame: &mut Frame, area: Rect, keys_width: usize) {
+        let remaining = (area.width as usize).saturating_sub(keys_width);
+        let text = if remaining > self.full_info.len() {
+            Some(&*self.full_info)
+        } else if remaining > self.broker.len() {
+            Some(&*self.broker)
+        } else if remaining > VERSION_TEXT.len() {
+            Some(VERSION_TEXT)
+        } else {
+            None
+        };
+        if let Some(text) = text {
+            #[expect(clippy::cast_possible_truncation)]
+            let info_area = Rect {
+                x: area.width.saturating_sub(text.len() as u16),
+                width: text.len() as u16,
+                ..area
+            };
+            frame.render_widget(Span::styled(text, VERSION_STYLE), info_area);
+        }
+    }
+
     pub fn draw(&self, frame: &mut Frame, area: Rect, app: &App) {
         let mut keys = Vec::new();
 
@@ -46,6 +68,12 @@ impl Footer {
             ElementInFocus::TopicOverview => {
                 add!("q", "Quit");
                 add!("/", "Search");
+                if app.topic_overview.filter.is_empty() {
+                    add!("f", "Filter");
+                } else {
+                    add!("f", "Edit Filter");
+                    add!("Esc", "Clear Filter");
+                }
                 add!("o", "Open all");
                 if !app.topic_overview.state.opened().is_empty() {
                     add!("O", "Close all");
@@ -76,6 +104,19 @@ impl Footer {
                 keys.push(Span::raw(" "));
                 keys.push(Span::raw(&app.topic_overview.search));
             }
+            ElementInFocus::TopicFilter => {
+                add!("Esc", "Clear");
+                add!("Enter", "Confirm");
+                keys.push(Span::styled(
+                    " Filter: ",
+                    Style::new()
+                        .fg(Color::Black)
+                        .bg(Color::LightGreen)
+                        .add_modifier(Modifier::BOLD),
+                ));
+                keys.push(Span::raw(" "));
+                keys.push(Span::raw(&app.topic_overview.filter));
+            }
             ElementInFocus::Payload => {
                 add!("q", "Quit");
                 if app.can_switch_to_history_table() {
@@ -99,34 +140,15 @@ impl Footer {
         let keys = Line::from(keys);
 
         #[expect(clippy::cast_possible_truncation)]
-        if matches!(app.focus, ElementInFocus::TopicSearch) {
+        if matches!(
+            app.focus,
+            ElementInFocus::TopicSearch | ElementInFocus::TopicFilter
+        ) {
             let x = area.left().saturating_add(keys.width() as u16);
             frame.set_cursor_position(Position { x, y: area.y });
         }
 
-        // Show version / broker when enough space
-        {
-            let remaining = (area.width as usize).saturating_sub(keys.width());
-            let text = if remaining > self.full_info.len() {
-                Some(&*self.full_info)
-            } else if remaining > self.broker.len() {
-                Some(&*self.broker)
-            } else if remaining > VERSION_TEXT.len() {
-                Some(VERSION_TEXT)
-            } else {
-                None // Not enough space -> show nothing
-            };
-            if let Some(text) = text {
-                #[expect(clippy::cast_possible_truncation)]
-                let area = Rect {
-                    x: area.width.saturating_sub(text.len() as u16),
-                    width: text.len() as u16,
-                    ..area
-                };
-                frame.render_widget(Span::styled(text, VERSION_STYLE), area);
-            }
-        }
-
+        self.render_version_info(frame, area, keys.width());
         frame.render_widget(keys, area);
     }
 }

--- a/src/interactive/mod.rs
+++ b/src/interactive/mod.rs
@@ -225,7 +225,18 @@ impl App {
                     self.focus = ElementInFocus::TopicSearch;
                     true
                 }
-                KeyCode::Esc => self.topic_overview.state.select(vec![]),
+                KeyCode::Char('f') => {
+                    self.focus = ElementInFocus::TopicFilter;
+                    true
+                }
+                KeyCode::Esc => {
+                    if self.topic_overview.filter.is_empty() {
+                        self.topic_overview.state.select(vec![])
+                    } else {
+                        self.topic_overview.filter.clear();
+                        true
+                    }
+                }
                 KeyCode::Enter | KeyCode::Char(' ') => self.topic_overview.state.toggle_selected(),
                 KeyCode::Down | KeyCode::Char('j') => self.topic_overview.state.key_down(),
                 KeyCode::Up | KeyCode::Char('k') => self.topic_overview.state.key_up(),
@@ -299,6 +310,31 @@ impl App {
                 KeyCode::Tab => {
                     self.focus = ElementInFocus::TopicOverview;
                     true
+                }
+                _ => false,
+            },
+            ElementInFocus::TopicFilter => match key.code {
+                KeyCode::Char(char) => {
+                    self.topic_overview.filter += &char.to_lowercase().to_string();
+                    true
+                }
+                KeyCode::Backspace => self.topic_overview.filter.pop().is_some(),
+                KeyCode::Esc => {
+                    self.topic_overview.filter.clear();
+                    self.focus = ElementInFocus::TopicOverview;
+                    true
+                }
+                KeyCode::Enter | KeyCode::Tab => {
+                    self.focus = ElementInFocus::TopicOverview;
+                    true
+                }
+                KeyCode::PageUp => {
+                    let page_jump = (self.topic_overview.last_area.height / 3) as usize;
+                    self.topic_overview.state.scroll_up(page_jump)
+                }
+                KeyCode::PageDown => {
+                    let page_jump = (self.topic_overview.last_area.height / 3) as usize;
+                    self.topic_overview.state.scroll_down(page_jump)
                 }
                 _ => false,
             },

--- a/src/interactive/mqtt_history.rs
+++ b/src/interactive/mqtt_history.rs
@@ -112,18 +112,43 @@ impl MqttHistory {
             .collect()
     }
 
-    /// Returns (`topic_amount`, `message_amount`, `TreeItem`s)
-    pub fn to_tree_items(&self) -> (usize, usize, Vec<TreeItem<'static, String>>) {
-        fn build_recursive(prefix: &[&str], node: NodeRef<Topic>) -> RecursiveTreeItemGenerator {
+    /// Returns (`topic_amount`, `message_amount`, `TreeItem`s).
+    ///
+    /// When `filter` is non-empty, only topics whose full path or latest payload contains
+    /// the filter string (case-insensitive) are included. Parent nodes are retained whenever
+    /// at least one descendant matches.
+    pub fn to_tree_items(&self, filter: &str) -> (usize, usize, Vec<TreeItem<'static, String>>) {
+        fn build_recursive(
+            prefix: &[&str],
+            node: NodeRef<Topic>,
+            filter: &str,
+        ) -> Option<RecursiveTreeItemGenerator> {
             let Topic { leaf, history } = node.value();
             let mut topic = prefix.to_vec();
             topic.push(leaf);
 
-            let entries_below = node.children().map(|node| build_recursive(&topic, node));
+            let children_entries: Vec<_> = node
+                .children()
+                .filter_map(|node| build_recursive(&topic, node, filter))
+                .collect();
+
+            let matches = filter.is_empty() || {
+                let filter_lower = filter.to_lowercase();
+                let full_topic = topic.join("/");
+                full_topic.to_lowercase().contains(&filter_lower)
+                    || history.last().is_some_and(|entry| {
+                        entry.payload.to_string().to_lowercase().contains(&filter_lower)
+                    })
+            };
+
+            if !matches && children_entries.is_empty() {
+                return None;
+            }
+
             let mut messages_below: usize = 0;
             let mut topics_below: usize = 0;
             let mut children = Vec::new();
-            for below in entries_below {
+            for below in children_entries {
                 messages_below = messages_below
                     .saturating_add(below.messages)
                     .saturating_add(below.messages_below);
@@ -143,19 +168,19 @@ impl MqttHistory {
                 Span::styled(meta, STYLE_DARKGRAY),
             ]);
 
-            RecursiveTreeItemGenerator {
+            Some(RecursiveTreeItemGenerator {
                 messages_below,
                 messages: history.len(),
                 topics_below,
                 tree_item: TreeItem::new(leaf.to_string(), text, children).unwrap(),
-            }
+            })
         }
 
         let children = self
             .tree
             .root()
             .children()
-            .map(|node| build_recursive(&[], node));
+            .filter_map(|node| build_recursive(&[], node, filter));
         let mut topics: usize = 0;
         let mut messages: usize = 0;
         let mut items = Vec::new();
@@ -220,7 +245,7 @@ fn topics_below_finds_itself_works() {
 #[test]
 fn tree_items_works() {
     let example = MqttHistory::example();
-    let (topics, messages, items) = example.to_tree_items();
+    let (topics, messages, items) = example.to_tree_items("");
     assert_eq!(topics, 4);
     assert_eq!(messages, 5);
     dbg!(&items);
@@ -228,4 +253,26 @@ fn tree_items_works() {
     assert_eq!(items[0].children().len(), 2);
     assert_eq!(items[1].children().len(), 0);
     assert_eq!(items[2].children().len(), 1);
+}
+
+#[test]
+fn tree_items_filtered_works() {
+    let example = MqttHistory::example();
+    // "foo" matches foo/bar and foo/test — "test", "testing/stuff" are hidden
+    let (topics, messages, items) = example.to_tree_items("foo");
+    assert_eq!(topics, 2);
+    assert_eq!(messages, 2);
+    assert_eq!(items.len(), 1); // only "foo" top-level node
+    assert_eq!(items[0].children().len(), 2); // foo/bar and foo/test
+}
+
+#[test]
+fn tree_items_filtered_by_payload_works() {
+    let example = MqttHistory::example();
+    // payload "D" is on "foo/bar"; "d" does not appear in any topic name
+    let (topics, messages, items) = example.to_tree_items("D");
+    assert_eq!(topics, 1);
+    assert_eq!(messages, 1);
+    assert_eq!(items.len(), 1); // only "foo" top-level node
+    assert_eq!(items[0].children().len(), 1); // "bar" only
 }

--- a/src/interactive/topic_overview.rs
+++ b/src/interactive/topic_overview.rs
@@ -9,6 +9,7 @@ use super::ui::{BORDERS_TOP_RIGHT, focus_color};
 
 #[derive(Default)]
 pub struct TopicOverview {
+    pub filter: String,
     pub last_area: Rect,
     pub search: String,
     pub state: TreeState<String>,
@@ -24,8 +25,15 @@ impl TopicOverview {
     }
 
     pub fn draw(&mut self, frame: &mut Frame, area: Rect, history: &MqttHistory, has_focus: bool) {
-        let (topic_amount, message_amount, tree_items) = history.to_tree_items();
-        let title = format!("Topics ({topic_amount}, {message_amount} messages)");
+        let (topic_amount, message_amount, tree_items) = history.to_tree_items(&self.filter);
+        let title = if self.filter.is_empty() {
+            format!("Topics ({topic_amount}, {message_amount} messages)")
+        } else {
+            format!(
+                "Topics ({topic_amount}, {message_amount} messages) [filter: {}]",
+                self.filter
+            )
+        };
         let focus_color = focus_color(has_focus);
         let widget = Tree::new(&tree_items)
             .unwrap()

--- a/src/interactive/ui.rs
+++ b/src/interactive/ui.rs
@@ -8,6 +8,7 @@ pub const STYLE_BOLD: Style = Style::new().add_modifier(Modifier::BOLD);
 pub enum ElementInFocus {
     TopicOverview,
     TopicSearch,
+    TopicFilter,
     Payload,
     HistoryTable,
     CleanRetainedPopup(String),


### PR DESCRIPTION
## Summary

Closes #103.

The existing `/` search navigates to matching topics and opens their subtrees but leaves all topics visible. This PR adds a distinct **filter** mode that hides non-matching topics entirely.

- Press `f` in the topic overview to enter filter mode
- Type any substring only topics whose full path **or** latest payload contains it (case-insensitive) are shown; parent nodes are kept when a descendant matches
- Press `Esc` in filter mode to clear the filter and return to overview
- Press `Enter` or `Tab` to lock the filter in and return focus to the overview (filter stays active for continued navigation)
- Press `Esc` in overview mode to clear an active filter (clears before deselecting)
- The active filter is shown in the topic pane title: `Topics (N, M messages) [filter: foo]`
- Footer shows `[f] Filter` when no filter is active, `[f] Edit Filter` + `[Esc] Clear Filter` when one is locked

## Changes

| File | Change |
|---|---|
| `src/interactive/ui.rs` | Add `TopicFilter` variant to `ElementInFocus` |
| `src/interactive/mqtt_history.rs` | `to_tree_items` accepts a `filter: &str`; `build_recursive` prunes non-matching branches |
| `src/interactive/topic_overview.rs` | Add `filter: String` field; pass to `to_tree_items`; show in block title |
| `src/interactive/mod.rs` | `f` keybind, `TopicFilter` arm, Esc-clears-filter |
| `src/interactive/footer.rs` | Filter hints in overview arm; full `TopicFilter` footer arm; extract `render_version_info` helper |
| `CHANGELOG.md` | Entry under `[Unreleased]` |

No new dependencies. No changes outside `src/interactive/`.

## Test plan

- `cargo clippy --all-targets -- -D warnings` passes clean
- `cargo test` 52 tests pass including two new filter-specific tests:
  - `tree_items_filtered_works` verifies non-matching topics are hidden
  - `tree_items_filtered_by_payload_works`  verifies payload-content matching